### PR TITLE
Make all functions private to avoid namespace pollution

### DIFF
--- a/plugin/winny.vim
+++ b/plugin/winny.vim
@@ -71,7 +71,7 @@ let s:numbers = {
       \ ]
       \ }
 
-function! DisplayNumber(number)
+function! s:DisplayNumber(number)
   if a:number < 0
     echoerr 'Number must be positive'
     return ''
@@ -92,9 +92,9 @@ function! DisplayNumber(number)
 endfunction
 
 " Define the function to display the window numbers
-function! ShowWindowNumbers()
+function! s:ShowWindowNumbers()
   for i in range(1, winnr('$'))
-    let content = DisplayNumber(i)
+    let content = s:DisplayNumber(i)
     let winid = win_getid(i)
     let row = win_screenpos(i)[0] + (winheight(i)) / 2
     let col = win_screenpos(i)[1] + (winwidth(i)) / 2
@@ -112,21 +112,21 @@ function! ShowWindowNumbers()
   endfor
 endfunction
 
-function! JumpWindow()
-    call ShowWindowNumbers()
+function! s:JumpWindow()
+    call s:ShowWindowNumbers()
     redraw
     let target = getcharstr()
     execute target . 'wincmd w'
 endfunction
 
-function! SwapWindows(target_win = v:null)
+function! s:SwapWindows(target_win = v:null)
     let cur_buffer = bufnr("%")
     let cur_win = winnr()
 
     if a:target_win != v:null
         let target_win = a:target_win
     else
-        call ShowWindowNumbers()
+        call s:ShowWindowNumbers()
         redraw
         let target_win = getcharstr()
     endif
@@ -137,9 +137,9 @@ function! SwapWindows(target_win = v:null)
     execute 'buffer ' . cur_buffer
 endfunction
 
-map <Plug>WinnyJumpWindow :call JumpWindow()<cr>
-map <Plug>WinnyShowWindows :call ShowWindowNumbers()<cr>
-map <Plug>WinnySwapWindows :call SwapWindows()<cr>
+map <Plug>WinnyJumpWindow :call <SID>JumpWindow()<cr>
+map <Plug>WinnyShowWindows :call <SID>ShowWindowNumbers()<cr>
+map <Plug>WinnySwapWindows :call <SID>SwapWindows()<cr>
 
 " suggested mappings
 " nnoremap <silent> <c-w><c-w> <Plug>WinnyJumpWindow


### PR DESCRIPTION
The way that the functions are defined, they're all in the global namespace, and that could cause trouble down the line. Prefixing them with `s:` makes them script-local, so the user can have their own functions named `JumpWindow` etc.

A different way to avoid namespace pollution would be to make them autoloaded. I'll prepare a different PR as an option.